### PR TITLE
Fixes, fixes everywhere

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ modmenu_version=1.16.8
 cloth_config_2_version=4.11.19
 
 # Mod Properties
-mod_version = 1.2.5
+mod_version = 1.2.7
 maven_group = dev.bernasss12
 archives_base_name = better-enchanted-books

--- a/src/main/java/dev/bernasss12/bebooks/BetterEnchantedBooks.java
+++ b/src/main/java/dev/bernasss12/bebooks/BetterEnchantedBooks.java
@@ -14,7 +14,6 @@ import net.minecraft.item.Items;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -53,6 +52,7 @@ public class BetterEnchantedBooks implements ClientModInitializer {
             return mapped;
         }
 
+        cachedColors.put(stack, DEFAULT_BOOK_STRIP_COLOR);
         return DEFAULT_BOOK_STRIP_COLOR;
     }
 

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/TooltipDrawerHelper.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/TooltipDrawerHelper.java
@@ -1,5 +1,7 @@
 package dev.bernasss12.bebooks.client.gui;
 
+import dev.bernasss12.bebooks.util.NBTUtils;
+import dev.bernasss12.bebooks.util.NBTUtils.EnchantmentCompound;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
@@ -8,8 +10,11 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TooltipDrawerHelper {
 
@@ -25,7 +30,7 @@ public class TooltipDrawerHelper {
         isEnchantmentIconListMapPopulated = true;
     }
 
-    private static List<ItemStack> addEnchantmentToList(Enchantment enchantment) {
+    private static List<ItemStack> addEnchantmentToList(@NotNull Enchantment enchantment) {
         List<ItemStack> list = new ArrayList<>();
         for (ItemStack icon : ModConfig.checkedItemsList) {
             if (enchantment.isAcceptableItem(icon)) list.add(icon);
@@ -34,7 +39,7 @@ public class TooltipDrawerHelper {
         return list;
     }
 
-    public static List<ItemStack> getAndComputeIfAbsent(Enchantment enchantment) {
+    public static List<ItemStack> getAndComputeIfAbsent(@NotNull Enchantment enchantment) {
         if (enchantmentIconListMap.containsKey(enchantment)) return enchantmentIconListMap.get(enchantment);
         else return addEnchantmentToList(enchantment);
     }
@@ -56,8 +61,10 @@ public class TooltipDrawerHelper {
             this.firstLine = firstLine;
             this.enchantments = new ArrayList<>();
             for (Tag enchantmentTag : enchantments) {
-                Enchantment enchantment = Registry.ENCHANTMENT.get(new Identifier(((CompoundTag) enchantmentTag).getString("id")));
-                this.enchantments.add(enchantment);
+                Enchantment enchantment = Registry.ENCHANTMENT.get(Identifier.tryParse(((CompoundTag) enchantmentTag).getString("id")));
+                if (enchantment != null) {
+                    this.enchantments.add(enchantment);
+                }
             }
         }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,6 +32,7 @@
   "depends": {
     "fabricloader": ">=0.9.0",
     "fabric": "*",
-    "minecraft": ">=1.16.2"
+    "minecraft": ">=1.16.2",
+    "cloth-config2": ">=4.8.0"
   }
 }


### PR DESCRIPTION
## Changelog

- fix 2 NullPointerExceptions when items have unregistered enchantments

Items can have enchantments on them which are not registered.
For testing you can give yourself such a book: `/give @s enchanted_book{StoredEnchantments:[{id:nonexistent,lvl:3}]} 1`
Tooltip sorting would crash (so much for my "sort should never throw an Exception"), as would rendering tooltip icons.

- fix sorting by translated name

I thought I broke it, but it was already broken in 1.2.5

- fix caching of default colored books

This I broke, caching is very important for performance (though default colored enchanted books are rare)

- fix some books being default colored because they use id "id" instead of "minecraft:id"
- add cloth-config2 as a 'depends'

Could be included in the build, though that would add 800kB.

- enable pretty-printing of config
- bump version to 1.2.7

I'll add some code comments soon.