### PR TITLE
Fix possible NullPointerException trying to draw tooltip icons

### DIFF
--- a/src/main/java/dev/bernasss12/bebooks/mixin/ScreenMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ScreenMixin.java
@@ -72,6 +72,9 @@ public abstract class ScreenMixin extends DrawableHelper {
 
     @Unique
     protected void drawTooltipIcons(List<? extends OrderedText> text, int x, int y) {
+        TooltipDrawerHelper.TooltipQueuedEntry entry = BetterEnchantedBooks.cachedTooltipIcons.get(BetterEnchantedBooks.enchantedItemStack.get());
+        if (entry == null) return;
+
         int maxLength = TooltipDrawerHelper.currentTooltipWidth;
         int translatedX = x + 12;
         int translatedY = y - 12;
@@ -90,7 +93,6 @@ public abstract class ScreenMixin extends DrawableHelper {
         RenderSystem.pushMatrix();
         RenderSystem.enableRescaleNormal();
         RenderSystem.translatef(0f, 0f, 401f);
-        TooltipDrawerHelper.TooltipQueuedEntry entry = BetterEnchantedBooks.cachedTooltipIcons.get(BetterEnchantedBooks.enchantedItemStack.get());
         translatedY += entry.getFirstLine() * 10 + 12;
         for (Enchantment enchantment : entry.getList()) {
             int xOffset = 4;


### PR DESCRIPTION
When using [Show Off](https://www.curseforge.com/minecraft/mc-mods/show-off) with an enchanted book, holding shift to show the tooltip icons (or having them set to always draw) will crash the game on mouse-over.

This comes back to the general issue of `enchantedItemStack` not always being set and `cachedTooltipIcons` will return `null`, thus producing a NPE.
Since this general issue is hard to fix, I retorted to the simple fix of skipping the whole method.

I should also say that since `cachedTooltipIcons` is a `WeakHashMap`, `get` *can always* return `null`, so this might fix some crashes in low memory situations as well.