### PR TITLE
update to 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -8,8 +8,8 @@ repositories {
 	maven { url "https://maven.terraformersmc.com/" }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name + "-" + project.minecraft_version
 version = project.mod_version
@@ -41,11 +41,7 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-
-	def targetVersion = 8
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = targetVersion
-	}
+	it.options.release = 16
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx3G
 
-# Fabric Properties https://fabricmc.net/use
-minecraft_version=1.16.5
-yarn_mappings=1.16.5+build.6
+# Fabric Properties https://fabricmc.net/versions.html
+minecraft_version=1.17
+yarn_mappings=1.17+build.10
 loader_version=0.11.3
 
 # Dependencies
-fabric_version=0.32.5+1.16
-modmenu_version=1.16.8
-cloth_config_2_version=4.11.19
+fabric_version=0.35.1+1.17
+modmenu_version=2.0.2
+cloth_config_2_version=5.0.34
 
 # Mod Properties
 mod_version = 1.2.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/dev/bernasss12/bebooks/BetterEnchantedBooks.java
+++ b/src/main/java/dev/bernasss12/bebooks/BetterEnchantedBooks.java
@@ -46,7 +46,7 @@ public class BetterEnchantedBooks implements ClientModInitializer {
         Integer cached = cachedColors.get(stack);
         if (cached != null) return cached;
 
-        Integer mapped = ModConfig.mappedEnchantmentColors.get(NBTUtils.getPriorityEnchantmentId(EnchantedBookItem.getEnchantmentTag(stack), ModConfig.colorPrioritySetting));
+        Integer mapped = ModConfig.mappedEnchantmentColors.get(NBTUtils.getPriorityEnchantmentId(EnchantedBookItem.getEnchantmentNbt(stack), ModConfig.colorPrioritySetting));
         if (mapped != null) {
             cachedColors.put(stack, mapped);
             return mapped;

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/ModConfig.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/ModConfig.java
@@ -77,8 +77,7 @@ public class ModConfig {
             }.getType());
             enchantmentDataMap = fromStoredData(storedEnchantmentDataMap);
         } catch (Exception e) {
-            LOGGER.error("Couldn't load enchantment data", e);
-            // In case map parsing fails create a new empty map and populate it with all registered enchantments with the default color.
+            if (!(e instanceof FileNotFoundException)) LOGGER.error("Couldn't load enchantment data", e);
             enchantmentDataMap = new HashMap<>();
         }
         int index = enchantmentDataMap.size();

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/TooltipDrawerHelper.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/TooltipDrawerHelper.java
@@ -4,9 +4,9 @@ import dev.bernasss12.bebooks.util.NBTUtils;
 import dev.bernasss12.bebooks.util.NBTUtils.EnchantmentCompound;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
@@ -57,11 +57,11 @@ public class TooltipDrawerHelper {
         private final int firstLine;
         private final List<Enchantment> enchantments;
 
-        public TooltipQueuedEntry(int firstLine, ListTag enchantments) {
+        public TooltipQueuedEntry(int firstLine, NbtList enchantments) {
             this.firstLine = firstLine;
             this.enchantments = new ArrayList<>();
-            for (Tag enchantmentTag : enchantments) {
-                Enchantment enchantment = Registry.ENCHANTMENT.get(Identifier.tryParse(((CompoundTag) enchantmentTag).getString("id")));
+            for (NbtElement enchantmentTag : enchantments) {
+                Enchantment enchantment = Registry.ENCHANTMENT.get(Identifier.tryParse(((NbtCompound) enchantmentTag).getString("id")));
                 if (enchantment != null) {
                     this.enchantments.add(enchantment);
                 }

--- a/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
@@ -12,8 +12,8 @@ import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
@@ -30,10 +30,10 @@ import java.util.List;
 public abstract class ItemStackMixin {
 
     @ModifyVariable(method = "appendEnchantments", argsOnly = true, at = @At("HEAD"))
-    private static ListTag appendEnchantmentsHead(ListTag tag, List<Text> tooltip, ListTag enchantments) {
+    private static NbtList appendEnchantmentsHead(NbtList tag, List<Text> tooltip, NbtList enchantments) {
         if (MinecraftClient.getInstance().currentScreen instanceof HandledScreen) {
             if (ModConfig.configsFirstLoaded && ModConfig.sortingSetting != ModConfig.SortingSetting.DISABLED) {
-                ListTag sortedEnchantments = NBTUtils.toListTag(NBTUtils.sorted(enchantments, ModConfig.sortingSetting, ModConfig.doKeepCursesBelow));
+                NbtList sortedEnchantments = NBTUtils.toListTag(NBTUtils.sorted(enchantments, ModConfig.sortingSetting, ModConfig.doKeepCursesBelow));
 
                 if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
                     BetterEnchantedBooks.cachedTooltipIcons.putIfAbsent(BetterEnchantedBooks.enchantedItemStack.get(),
@@ -51,8 +51,8 @@ public abstract class ItemStackMixin {
     }
     // ItemStack.appendEnchantments's lambda
     @SuppressWarnings("UnresolvedMixinReference")
-    @Inject(at = @At(value = "HEAD"), method = "method_17869(Ljava/util/List;Lnet/minecraft/nbt/CompoundTag;Lnet/minecraft/enchantment/Enchantment;)V")
-    private static void setShowEnchantmentMaxLevel(List<Text> tooltip, CompoundTag tag, Enchantment enchantment, CallbackInfo info) {
+    @Inject(at = @At(value = "HEAD"), method = "method_17869(Ljava/util/List;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/enchantment/Enchantment;)V")
+    private static void setShowEnchantmentMaxLevel(List<Text> tooltip, NbtCompound tag, Enchantment enchantment, CallbackInfo info) {
         if (ModConfig.doShowEnchantmentMaxLevel) {
             BetterEnchantedBooks.shouldShowEnchantmentMaxLevel.set(true);
         }
@@ -60,8 +60,8 @@ public abstract class ItemStackMixin {
 
     // ItemStack.appendEnchantments's lambda
     @SuppressWarnings("UnresolvedMixinReference")
-    @Inject(at = @At(value = "TAIL"), method = "method_17869(Ljava/util/List;Lnet/minecraft/nbt/CompoundTag;Lnet/minecraft/enchantment/Enchantment;)V")
-    private static void addTooltipSpacers(List<Text> tooltip, CompoundTag tag, Enchantment enchantment, CallbackInfo info) {
+    @Inject(at = @At(value = "TAIL"), method = "method_17869(Ljava/util/List;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/enchantment/Enchantment;)V")
+    private static void addTooltipSpacers(List<Text> tooltip, NbtCompound tag, Enchantment enchantment, CallbackInfo info) {
         if (MinecraftClient.getInstance().currentScreen instanceof HandledScreen) {
             if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
                 switch (ModConfig.tooltipSetting) {

--- a/src/main/java/dev/bernasss12/bebooks/util/NBTUtils.java
+++ b/src/main/java/dev/bernasss12/bebooks/util/NBTUtils.java
@@ -6,9 +6,9 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 @Environment(EnvType.CLIENT)
 public final class NBTUtils {
 
-    public static Stream<EnchantmentCompound> sorted(ListTag listTag, ModConfig.SortingSetting mode, boolean cursesBelow) {
+    public static Stream<EnchantmentCompound> sorted(NbtList listTag, ModConfig.SortingSetting mode, boolean cursesBelow) {
         Comparator<EnchantmentCompound> comparator;
 
         if (cursesBelow) {
@@ -44,17 +44,17 @@ public final class NBTUtils {
         return listTag.stream().map(EnchantmentCompound::new).sorted(comparator);
     }
 
-    public static ListTag toListTag(Stream<EnchantmentCompound> stream) {
-        ListTag listTag = new ListTag();
+    public static NbtList toListTag(Stream<EnchantmentCompound> stream) {
+        NbtList listTag = new NbtList();
         stream.forEachOrdered(tag -> listTag.add(tag.asCompoundTag()));
         return listTag;
     }
 
-    public static boolean hasCurses(ListTag listTag) {
+    public static boolean hasCurses(NbtList listTag) {
         return listTag.stream().map(EnchantmentCompound::new).anyMatch(EnchantmentCompound::isCursed);
     }
 
-    public static String getPriorityEnchantmentId(ListTag listTag, ModConfig.SortingSetting mode) {
+    public static String getPriorityEnchantmentId(NbtList listTag, ModConfig.SortingSetting mode) {
         Stream<EnchantmentCompound> candidates = sorted(listTag, mode, true)
             .filter(EnchantmentCompound::isRegistered);
 
@@ -69,19 +69,19 @@ public final class NBTUtils {
     }
 
     public static class EnchantmentCompound {
-        @NotNull private final CompoundTag compound;
+        @NotNull private final NbtCompound compound;
         private final Enchantment enchantment;
         private String id = null;
         private String translatedName = null;
         private int index = -1;
         private boolean isCursed = false;
 
-        public EnchantmentCompound(@NotNull Tag tag) {
+        public EnchantmentCompound(@NotNull NbtElement tag) {
             if (tag.getType() != 10) {
                 throw new AssertionError("tag is not a CompoundTag");
             }
 
-            this.compound = (CompoundTag) tag;
+            this.compound = (NbtCompound) tag;
 
             Identifier identifier = Identifier.tryParse(compound.getString("id"));
             this.enchantment = Registry.ENCHANTMENT.get(identifier);
@@ -110,7 +110,7 @@ public final class NBTUtils {
         }
 
         @NotNull
-        public CompoundTag asCompoundTag() {
+        public NbtCompound asCompoundTag() {
             return compound;
         }
 

--- a/src/main/resources/bebooks.mixins.json
+++ b/src/main/resources/bebooks.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "dev.bernasss12.bebooks.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "client": [
     "EnchantedBookItemMixin",
     "EnchantmentMixin",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=0.9.0",
     "fabric": "*",
-    "minecraft": ">=1.16.2",
-    "cloth-config2": ">=4.8.0"
+    "minecraft": ">=1.17.0",
+    "cloth-config2": ">=5.0.0"
   }
 }


### PR DESCRIPTION
The process looked like this:
- run `gradlew migrateMappings --mappings "1.17+build.10"`
 - update to gradle 7.0.2, remove deprecated `jcenter()`
- update to loom 0.8, Java 16 (now required for building)
- update dependencies
- mixin into new `renderTooltipFromComponents()` taking `List<TooltipComponent>` instead of `renderOrderedTooltip()` taking `List<? extends OrderedText>` because the latter directly calls the former

Note: This could have unintended side-effects I'm not aware of.

- fix `drawTooltipIcons()`: `RenderSystem.scalef()` doesn't exist anymore, replaced by `matrices.scale()`. `RenderSystem.enableRescaleNormal()` seems to have no replacement at all, so I just left it out - let's hope this is fine.

- fix `drawScaledItem()`:

Here, `matrices.scale()` doesn't work because `renderGuiItemIcon()` uses a different `MatrixStack`, namely `RenderSystem.getModelViewStack()`. It also calls `RenderSystem.applyModelViewMatrix();` after it changing it - I have no idea what the latter does, but I applied it anyways.

---

I didn't do a ton of testing but so far everything seems fine.
You might wanna pull this and push it to a separate branch because GitHub doesn't allow PRs to new branches