### PR TITLE
Fix missing tooltip icons when enchantment sorting is disabled

### DIFF
--- a/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
@@ -32,20 +32,18 @@ public abstract class ItemStackMixin {
     @ModifyVariable(method = "appendEnchantments", argsOnly = true, at = @At("HEAD"))
     private static NbtList appendEnchantmentsHead(NbtList tag, List<Text> tooltip, NbtList enchantments) {
         if (MinecraftClient.getInstance().currentScreen instanceof HandledScreen) {
-            if (ModConfig.configsFirstLoaded && ModConfig.sortingSetting != ModConfig.SortingSetting.DISABLED) {
-                NbtList sortedEnchantments = NBTUtils.toListTag(NBTUtils.sorted(enchantments, ModConfig.sortingSetting, ModConfig.doKeepCursesBelow));
+            NbtList sortedEnchantments = NBTUtils.toListTag(NBTUtils.sorted(enchantments, ModConfig.sortingSetting, ModConfig.doKeepCursesBelow));
 
-                if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
-                    BetterEnchantedBooks.cachedTooltipIcons.putIfAbsent(BetterEnchantedBooks.enchantedItemStack.get(),
-                            new TooltipDrawerHelper.TooltipQueuedEntry(tooltip.size(), sortedEnchantments));
-                }
-
-                TooltipDrawerHelper.currentTooltipWidth = MinecraftClient.getInstance().textRenderer
-                                                                  .getWidth(tooltip.stream()
-                                                                                   .max(Comparator.comparing(line -> MinecraftClient.getInstance().textRenderer.getWidth(line)))
-                                                                                   .orElse(new LiteralText("")));
-                return sortedEnchantments;
+            if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
+                BetterEnchantedBooks.cachedTooltipIcons.putIfAbsent(BetterEnchantedBooks.enchantedItemStack.get(),
+                        new TooltipDrawerHelper.TooltipQueuedEntry(tooltip.size(), sortedEnchantments));
             }
+
+            TooltipDrawerHelper.currentTooltipWidth = MinecraftClient.getInstance().textRenderer
+                                                              .getWidth(tooltip.stream()
+                                                                               .max(Comparator.comparing(line -> MinecraftClient.getInstance().textRenderer.getWidth(line)))
+                                                                               .orElse(new LiteralText("")));
+            return sortedEnchantments;
         }
         return tag;
     }

--- a/src/main/java/dev/bernasss12/bebooks/mixin/ScreenMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ScreenMixin.java
@@ -7,17 +7,14 @@ import dev.bernasss12.bebooks.client.gui.TooltipDrawerHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.text.OrderedText;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -106,7 +103,6 @@ public abstract class ScreenMixin extends DrawableHelper {
             }
             translatedY += 20;
         }
-        matrices.translate(0, 0, -401);
         matrices.pop();
     }
 
@@ -116,12 +112,13 @@ public abstract class ScreenMixin extends DrawableHelper {
         int scaledY = (int) (y / scale);
 
         MatrixStack matrices = RenderSystem.getModelViewStack();
+        matrices.push();
         matrices.scale(scale, scale, 1.0f);
         RenderSystem.applyModelViewMatrix();
 
         itemRenderer.renderGuiItemIcon(stack, scaledX - 8, scaledY);
 
-        matrices.scale(1 / scale, 1 / scale, 1.0f);
+        matrices.pop();
         RenderSystem.applyModelViewMatrix();
     }
 }


### PR DESCRIPTION
When enchantment sorting is disabled, `appendEnchantmentsHead()` which is responsible for filling `cachedTooltipIcons` is skipped and thus the icons don't render.

The fix is to simply remove the condition
`if (ModConfig.configsFirstLoaded && ModConfig.sortingSetting != ModConfig.SortingSetting.DISABLED) {`
(The first condition should always be true since the config is loaded on title screen.)

I also looked at the tooltip render code again, I'm now much more confident it is actually correct.
Instead of applying inverse operations, `push()`/`pop()` should be used.

In general, render operations should look like

- `matrices.push()`
- modify `matrices`
- do the actual rendering
- `matrices.pop()`

If  `matrices` is `RenderSystem.getModelViewStack()` then do ``RenderSystem.applyModelViewMatrix();`` after modifying `matrices` and `matrices.pop()`.