### PR TITLE
Refactor config

### DIFF
--- a/src/main/java/dev/bernasss12/bebooks/BetterEnchantedBooks.java
+++ b/src/main/java/dev/bernasss12/bebooks/BetterEnchantedBooks.java
@@ -1,6 +1,7 @@
 package dev.bernasss12.bebooks;
 
 import dev.bernasss12.bebooks.client.gui.ModConfig;
+import dev.bernasss12.bebooks.client.gui.ModConfig.EnchantmentData;
 import dev.bernasss12.bebooks.client.gui.ModConstants;
 import dev.bernasss12.bebooks.client.gui.TooltipDrawerHelper;
 import dev.bernasss12.bebooks.util.NBTUtils;
@@ -27,16 +28,14 @@ public class BetterEnchantedBooks implements ClientModInitializer {
     private static Map<ItemStack, Integer> cachedColors;
     public static Map<ItemStack, TooltipDrawerHelper.TooltipQueuedEntry> cachedTooltipIcons;
 
-    public static ThreadLocal<ItemStack> enchantedItemStack;
-    public static ThreadLocal<Boolean> shouldShowEnchantmentMaxLevel;
+    public static final ThreadLocal<ItemStack> enchantedItemStack = ThreadLocal.withInitial(() -> ItemStack.EMPTY);
+    public static final ThreadLocal<Boolean> shouldShowEnchantmentMaxLevel = ThreadLocal.withInitial(() -> false);
 
     @Override
     public void onInitializeClient() {
-        ModConstants.populateDefaultColorsMap();
         cachedColors = new WeakHashMap<>();
         cachedTooltipIcons = new WeakHashMap<>();
-        enchantedItemStack = ThreadLocal.withInitial(() -> ItemStack.EMPTY);
-        shouldShowEnchantmentMaxLevel = ThreadLocal.withInitial(() -> false);
+
         ColorProviderRegistry.ITEM.register((stack, tintIndex) -> tintIndex > 0 ? getColorFromEnchantmentList(stack) : -1, Items.ENCHANTED_BOOK);
     }
 
@@ -46,10 +45,10 @@ public class BetterEnchantedBooks implements ClientModInitializer {
         Integer cached = cachedColors.get(stack);
         if (cached != null) return cached;
 
-        Integer mapped = ModConfig.mappedEnchantmentColors.get(NBTUtils.getPriorityEnchantmentId(EnchantedBookItem.getEnchantmentNbt(stack), ModConfig.colorPrioritySetting));
-        if (mapped != null) {
-            cachedColors.put(stack, mapped);
-            return mapped;
+        EnchantmentData data = ModConfig.enchantmentDataMap.get(NBTUtils.getPriorityEnchantmentId(EnchantedBookItem.getEnchantmentNbt(stack), ModConfig.colorPrioritySetting));
+        if (data != null) {
+            cachedColors.put(stack, data.color);
+            return data.color;
         }
 
         cachedColors.put(stack, DEFAULT_BOOK_STRIP_COLOR);

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/ModConstants.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/ModConstants.java
@@ -6,89 +6,83 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ModConstants {
     protected static final int SETTINGS_VERSION = 2;
 
-
-    protected static final List<ItemStack> DEFAULT_CHECKED_ITEMS_LIST = Arrays.asList(
-            new ItemStack(Items.DIAMOND_SWORD),
-            new ItemStack(Items.DIAMOND_PICKAXE),
-            new ItemStack(Items.DIAMOND_AXE),
-            new ItemStack(Items.DIAMOND_SHOVEL),
-            new ItemStack(Items.DIAMOND_HOE),
-            new ItemStack(Items.BOW),
-            new ItemStack(Items.CROSSBOW),
-            new ItemStack(Items.FISHING_ROD),
-            new ItemStack(Items.TRIDENT),
-            new ItemStack(Items.DIAMOND_HELMET),
-            new ItemStack(Items.DIAMOND_CHESTPLATE),
-            new ItemStack(Items.DIAMOND_LEGGINGS),
-            new ItemStack(Items.DIAMOND_BOOTS),
-            new ItemStack(Items.ELYTRA),
-            new ItemStack(Items.SHIELD),
-            new ItemStack(Items.SHEARS),
-            new ItemStack(Items.CARROT_ON_A_STICK),
-            new ItemStack(Items.WARPED_FUNGUS_ON_A_STICK),
-            new ItemStack(Items.FLINT_AND_STEEL)
+    public static final List<ItemStack> DEFAULT_CHECKED_ITEMS_LIST = List.of(
+        new ItemStack(Items.DIAMOND_SWORD),
+        new ItemStack(Items.DIAMOND_PICKAXE),
+        new ItemStack(Items.DIAMOND_AXE),
+        new ItemStack(Items.DIAMOND_SHOVEL),
+        new ItemStack(Items.DIAMOND_HOE),
+        new ItemStack(Items.BOW),
+        new ItemStack(Items.CROSSBOW),
+        new ItemStack(Items.FISHING_ROD),
+        new ItemStack(Items.TRIDENT),
+        new ItemStack(Items.DIAMOND_HELMET),
+        new ItemStack(Items.DIAMOND_CHESTPLATE),
+        new ItemStack(Items.DIAMOND_LEGGINGS),
+        new ItemStack(Items.DIAMOND_BOOTS),
+        new ItemStack(Items.ELYTRA),
+        new ItemStack(Items.SHIELD),
+        new ItemStack(Items.SHEARS),
+        new ItemStack(Items.CARROT_ON_A_STICK),
+        new ItemStack(Items.WARPED_FUNGUS_ON_A_STICK),
+        new ItemStack(Items.FLINT_AND_STEEL)
     );
 
     // Default enchantment colors as suggested by twusya on https://www.curseforge.com/minecraft/mc-mods/better-enchanted-books#c47
-    public static final Map<Enchantment, Integer> DEFAULT_ENCHANTMENT_COLORS = new HashMap<>();
+    public static final Map<Enchantment, Integer> DEFAULT_ENCHANTMENT_COLORS = Map.ofEntries(
+        Map.entry(Enchantments.AQUA_AFFINITY, 0x6e7af7),
+        Map.entry(Enchantments.BANE_OF_ARTHROPODS, 0x0f5160),
+        Map.entry(Enchantments.BLAST_PROTECTION, 0x442e62),
+        Map.entry(Enchantments.CHANNELING, 0xaef5ff),
+        Map.entry(Enchantments.BINDING_CURSE, 0x274d1e),
+        Map.entry(Enchantments.VANISHING_CURSE, 0x171220),
+        Map.entry(Enchantments.DEPTH_STRIDER, 0x9cdbff),
+        Map.entry(Enchantments.EFFICIENCY, 0xfff164),
+        Map.entry(Enchantments.FEATHER_FALLING, 0xfff0d1),
+        Map.entry(Enchantments.FIRE_ASPECT, 0xff7516),
+        Map.entry(Enchantments.FIRE_PROTECTION, 0xc4aaa5),
+        Map.entry(Enchantments.FLAME, 0xff7516),
+        Map.entry(Enchantments.FORTUNE, 0xffb65b),
+        Map.entry(Enchantments.FROST_WALKER, 0x90b4ff),
+        Map.entry(Enchantments.IMPALING, 0xc5133a),
+        Map.entry(Enchantments.INFINITY, 0x7b5be7),
+        Map.entry(Enchantments.KNOCKBACK, 0x605b60),
+        Map.entry(Enchantments.LOOTING, 0xffb65b),
+        Map.entry(Enchantments.LOYALTY, 0x6ec4b1),
+        Map.entry(Enchantments.LUCK_OF_THE_SEA, 0x4be850),
+        Map.entry(Enchantments.LURE, 0xff0000),
+        Map.entry(Enchantments.MENDING, 0xcaff61),
+        Map.entry(Enchantments.MULTISHOT, 0xffb301),
+        Map.entry(Enchantments.PIERCING, 0x337b50),
+        Map.entry(Enchantments.POWER, 0xc5133a),
+        Map.entry(Enchantments.PROJECTILE_PROTECTION, 0xcccdd5),
+        Map.entry(Enchantments.PROTECTION, 0xa5afc4),
+        Map.entry(Enchantments.PUNCH, 0x605b60),
+        Map.entry(Enchantments.QUICK_CHARGE, 0xff0000),
+        Map.entry(Enchantments.RESPIRATION, 0x7ad5ff),
+        Map.entry(Enchantments.RIPTIDE, 0xaccff1),
+        Map.entry(Enchantments.SHARPNESS, 0xc5133a),
+        Map.entry(Enchantments.SILK_TOUCH, 0xffffff),
+        Map.entry(Enchantments.SMITE, 0xbf5f2e),
+        Map.entry(Enchantments.SOUL_SPEED, 0x41342c),
+        Map.entry(Enchantments.SWEEPING, 0xffb301),
+        Map.entry(Enchantments.THORNS, 0x560d0b),
+        Map.entry(Enchantments.UNBREAKING, 0x5c3350)
+    );
 
-    public static void populateDefaultColorsMap() {
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.AQUA_AFFINITY, 0x6e7af7);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.BANE_OF_ARTHROPODS, 0x0f5160);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.BLAST_PROTECTION, 0x442e62);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.CHANNELING, 0xaef5ff);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.BINDING_CURSE, 0x274d1e);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.VANISHING_CURSE, 0x171220);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.DEPTH_STRIDER, 0x9cdbff);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.EFFICIENCY, 0xfff164);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.FEATHER_FALLING, 0xfff0d1);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.FIRE_ASPECT, 0xff7516);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.FIRE_PROTECTION, 0xc4aaa5);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.FLAME, 0xff7516);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.FORTUNE, 0xffb65b);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.FROST_WALKER, 0x90b4ff);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.IMPALING, 0xc5133a);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.INFINITY, 0x7b5be7);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.KNOCKBACK, 0x605b60);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.LOOTING, 0xffb65b);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.LOYALTY, 0x6ec4b1);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.LUCK_OF_THE_SEA, 0x4be850);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.LURE, 0xff0000);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.MENDING, 0xcaff61);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.MULTISHOT, 0xffb301);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.PIERCING, 0x337b50);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.POWER, 0xc5133a);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.PROJECTILE_PROTECTION, 0xcccdd5);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.PROTECTION, 0xa5afc4);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.PUNCH, 0x605b60);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.QUICK_CHARGE, 0xff0000);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.RESPIRATION, 0x7ad5ff);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.RIPTIDE, 0xaccff1);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.SHARPNESS, 0xc5133a);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.SILK_TOUCH, 0xffffff);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.SMITE, 0xbf5f2e);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.SOUL_SPEED, 0x41342c);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.SWEEPING, 0xffb301);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.THORNS, 0x560d0b);
-        DEFAULT_ENCHANTMENT_COLORS.put(Enchantments.UNBREAKING, 0x5c3350);
-    }
-
-    protected static final boolean DEFAULT_SHOW_ENCHANTMENT_MAX_LEVEL = false;
-    protected static final ModConfig.TooltipSetting DEFAULT_TOOLTIP_SETTING = ModConfig.TooltipSetting.ON_SHIFT;
-    protected static final ModConfig.SortingSetting DEFAULT_SORTING_SETTING = ModConfig.SortingSetting.ALPHABETICALLY;
-    protected static final boolean DEFAULT_KEEP_CURSES_BELOW = true;
-    protected static final boolean DEFAULT_COLOR_BOOKS = true;
-    protected static final boolean DEFAULT_CURSE_COLOR_OVERRIDE = true;
-    protected static final ModConfig.SortingSetting DEFAULT_COLOR_PRIORITY_SETTING = ModConfig.SortingSetting.ALPHABETICALLY;
+    public static final boolean DEFAULT_SHOW_ENCHANTMENT_MAX_LEVEL = false;
+    public static final ModConfig.TooltipSetting DEFAULT_TOOLTIP_SETTING = ModConfig.TooltipSetting.ON_SHIFT;
+    public static final ModConfig.SortingSetting DEFAULT_SORTING_SETTING = ModConfig.SortingSetting.ALPHABETICALLY;
+    public static final boolean DEFAULT_KEEP_CURSES_BELOW = true;
+    public static final boolean DEFAULT_COLOR_BOOKS = true;
+    public static final boolean DEFAULT_CURSE_COLOR_OVERRIDE = true;
+    public static final ModConfig.SortingSetting DEFAULT_COLOR_PRIORITY_SETTING = ModConfig.SortingSetting.ALPHABETICALLY;
     public static final int DEFAULT_BOOK_STRIP_COLOR = 0xc5133a;
-    protected static final Boolean DEFAULT_GLINT_SETTING = false;
-
-    public static final String MODID = "bebooks";
+    public static final Boolean DEFAULT_GLINT_SETTING = false;
 }

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/TooltipDrawerHelper.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/TooltipDrawerHelper.java
@@ -1,7 +1,5 @@
 package dev.bernasss12.bebooks.client.gui;
 
-import dev.bernasss12.bebooks.util.NBTUtils;
-import dev.bernasss12.bebooks.util.NBTUtils.EnchantmentCompound;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
@@ -13,8 +11,6 @@ import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TooltipDrawerHelper {
 

--- a/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
@@ -36,17 +36,18 @@ public abstract class ItemStackMixin {
 
             if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
                 BetterEnchantedBooks.cachedTooltipIcons.putIfAbsent(BetterEnchantedBooks.enchantedItemStack.get(),
-                        new TooltipDrawerHelper.TooltipQueuedEntry(tooltip.size(), sortedEnchantments));
+                    new TooltipDrawerHelper.TooltipQueuedEntry(tooltip.size(), sortedEnchantments));
             }
 
             TooltipDrawerHelper.currentTooltipWidth = MinecraftClient.getInstance().textRenderer
-                                                              .getWidth(tooltip.stream()
-                                                                               .max(Comparator.comparing(line -> MinecraftClient.getInstance().textRenderer.getWidth(line)))
-                                                                               .orElse(new LiteralText("")));
+                .getWidth(tooltip.stream()
+                    .max(Comparator.comparing(line -> MinecraftClient.getInstance().textRenderer.getWidth(line)))
+                    .orElse(new LiteralText("")));
             return sortedEnchantments;
         }
         return tag;
     }
+
     // ItemStack.appendEnchantments's lambda
     @SuppressWarnings("UnresolvedMixinReference")
     @Inject(at = @At(value = "HEAD"), method = "method_17869(Ljava/util/List;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/enchantment/Enchantment;)V")

--- a/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ItemStackMixin.java
@@ -32,20 +32,18 @@ public abstract class ItemStackMixin {
     @ModifyVariable(method = "appendEnchantments", argsOnly = true, at = @At("HEAD"))
     private static NbtList appendEnchantmentsHead(NbtList tag, List<Text> tooltip, NbtList enchantments) {
         if (MinecraftClient.getInstance().currentScreen instanceof HandledScreen) {
-            if (ModConfig.configsFirstLoaded && ModConfig.sortingSetting != ModConfig.SortingSetting.DISABLED) {
-                NbtList sortedEnchantments = NBTUtils.toListTag(NBTUtils.sorted(enchantments, ModConfig.sortingSetting, ModConfig.doKeepCursesBelow));
+            NbtList sortedEnchantments = NBTUtils.toListTag(NBTUtils.sorted(enchantments, ModConfig.sortingSetting, ModConfig.doKeepCursesBelow));
 
-                if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
-                    BetterEnchantedBooks.cachedTooltipIcons.putIfAbsent(BetterEnchantedBooks.enchantedItemStack.get(),
-                            new TooltipDrawerHelper.TooltipQueuedEntry(tooltip.size(), sortedEnchantments));
-                }
-
-                TooltipDrawerHelper.currentTooltipWidth = MinecraftClient.getInstance().textRenderer
-                                                                  .getWidth(tooltip.stream()
-                                                                                   .max(Comparator.comparing(line -> MinecraftClient.getInstance().textRenderer.getWidth(line)))
-                                                                                   .orElse(new LiteralText("")));
-                return sortedEnchantments;
+            if (BetterEnchantedBooks.enchantedItemStack.get().getItem().equals(Items.ENCHANTED_BOOK)) {
+                BetterEnchantedBooks.cachedTooltipIcons.putIfAbsent(BetterEnchantedBooks.enchantedItemStack.get(),
+                        new TooltipDrawerHelper.TooltipQueuedEntry(tooltip.size(), sortedEnchantments));
             }
+
+            TooltipDrawerHelper.currentTooltipWidth = MinecraftClient.getInstance().textRenderer
+                                                              .getWidth(tooltip.stream()
+                                                                               .max(Comparator.comparing(line -> MinecraftClient.getInstance().textRenderer.getWidth(line)))
+                                                                               .orElse(new LiteralText("")));
+            return sortedEnchantments;
         }
         return tag;
     }

--- a/src/main/java/dev/bernasss12/bebooks/mixin/ScreenMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/ScreenMixin.java
@@ -7,17 +7,14 @@ import dev.bernasss12.bebooks.client.gui.TooltipDrawerHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.text.OrderedText;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -106,7 +103,6 @@ public abstract class ScreenMixin extends DrawableHelper {
             }
             translatedY += 20;
         }
-        matrices.translate(0, 0, -401);
         matrices.pop();
     }
 
@@ -116,12 +112,13 @@ public abstract class ScreenMixin extends DrawableHelper {
         int scaledY = (int) (y / scale);
 
         MatrixStack matrices = RenderSystem.getModelViewStack();
+        matrices.push();
         matrices.scale(scale, scale, 1.0f);
         RenderSystem.applyModelViewMatrix();
 
         itemRenderer.renderGuiItemIcon(stack, scaledX - 8, scaledY);
 
-        matrices.scale(1 / scale, 1 / scale, 1.0f);
+        matrices.pop();
         RenderSystem.applyModelViewMatrix();
     }
 }

--- a/src/main/java/dev/bernasss12/bebooks/mixin/TitleScreenMixin.java
+++ b/src/main/java/dev/bernasss12/bebooks/mixin/TitleScreenMixin.java
@@ -17,7 +17,8 @@ public abstract class TitleScreenMixin {
     private void init(CallbackInfo info) {
         if (!ModConfig.configsFirstLoaded) {
             TooltipDrawerHelper.populateEnchantmentIconList();
-            ModConfig.loadConfig();
+            ModConfig.loadAndPopulateConfig();
+            ModConfig.saveConfig();
         }
     }
 }


### PR DESCRIPTION
I based this on #40, so please look at that first.
This is basically a continuation of #31.

## Changelog

- remove `mappedEnchantment*`, use `enchantmentDataMap` directly

The data in `mappedEnchantmentColors`, `mappedEnchantmentIndices` was redundant to what's in `enchantmentDataMap` and `mappedEnchantmentTargets` wasn't being used.

- use "modern" IO (`Path`, `Files`), use try-with-resources

This is probably the biggest part.
[try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) ensures the reader/writer/`Closeable` is always being closed.
`Path` is basically the "modern" `File` while `Files` (note the 's') has tons of useful one-liner methods like `readString()` that simplify a lot of common operations without sacrificing performance.

- strictly distinguish between loading and saving (e.g. don't call `saveConfig()` from `loadConfig()`)

This was really confusing to read, I wouldn't be surprised if there was a bug somewhere in there.
To "compensate" for this, a `saveConfig()` was put in the title screen mixin, which will generate the default config on first load (and also add new enchantments to the enchantment_data.json).

- extract registry access into `populateEnchantmentData()` and rename `loadConfig()` to `loadAndPopulateConfig()`

This is to make the prerequisites for loading more clear:
Other mods need to have their enchantments registered before the title screen mixin (and thereby `populateEnchantmentData()`) is executed.

- extract setting defaults into `loadConfigDefaults()`

- combine `StoredEnchantmentData` and `EnchantmentData`, mark non-stored fields `transient`, remove `fromStoredData()`, `toStoredData()`

Wanted to do this back then, this makes reading and writing the enchantment data much easier.
The only thing that one needs to be careful of when using Gson or other serialization methods is that you cannot assume that constructors are being called, not even default constructors.
This is basically the reason why `populateEnchantmentData()` starts with putting data into `EnchantmentData`.

- initialize `DEFAULT_ENCHANTMENT_COLORS` directly

`Map.of()` (for up to 10 entries) or `Map.ofEntries()` are just a really nice way to define immutable maps.
I also used `List.of` instead of `Arrays.asList` so that all values in `ModConstants` are immutable.

I'll probably add some more comments.