### PR TITLE
Compatibility update (for 1.18)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ modmenu_version=3.2.2
 cloth_config_2_version=6.2.62
 
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.3.1
 maven_group=dev.bernasss12
 archives_base_name=better-enchanted-books

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/tooltip/IconTooltipComponent.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/tooltip/IconTooltipComponent.java
@@ -34,5 +34,6 @@ public record IconTooltipComponent(List<ItemStack> icons) implements TooltipComp
             itemRenderer.renderInGuiWithOverrides(icons.get(i), scaledX + scaledOffset * i, scaledY, -1);
         }
         matrices.pop();
+        RenderSystem.applyModelViewMatrix();
     }
 }

--- a/src/main/java/dev/bernasss12/bebooks/util/text/IconTooltipDataText.java
+++ b/src/main/java/dev/bernasss12/bebooks/util/text/IconTooltipDataText.java
@@ -20,7 +20,7 @@ public record IconTooltipDataText(List<ItemStack> icons) implements OrderedText,
 
     @Override
     public String asString() {
-        return "This is not supposed to be used as an actual string.";
+        return "";
     }
 
     @Override
@@ -30,7 +30,7 @@ public record IconTooltipDataText(List<ItemStack> icons) implements OrderedText,
 
     @Override
     public MutableText copy() {
-        return new LiteralText(asString() + " Do not try to copy this.");
+        return new LiteralText(asString());
     }
 
     @Override


### PR DESCRIPTION
## ToolTip Fix

`IconTooltipDataText` had some dummy text that was supposed to warn about conflicts - and it did!

![tooltipfix](https://user-images.githubusercontent.com/8464472/174386340-e4c5c348-f689-4354-8bcc-be61c6e25228.png)

This is with ToolTip Fix, which reads the string, sees the tooltip would be too large and hence splits the text up into multiple lines, making the string visible - removing the icons in the process too!

A simple fix is to remove the dummy text, that way ToolTip Fix should never try to split it up.
This might result in the icons rendering outside the tooltip, but there's no clear way to fix that and this is much better than the alternative.

## Rendering glitches

The tooltip icons were previously rendered like this:
```
MatrixStack matrices = RenderSystem.getModelViewStack();
matrices.push();
matrices.scale(0.5f, 0.5f, 1.0f);
do the stuff
matrices.pop();
```

Back then there was the question if `RenderSystem.applyModelViewMatrix();` was not needed here - it didn't appear so and you might expect the `matrices.pop();` should already revert the changes.

Turns out it doesn't. Here's e.g. how Legendary Tooltips look when tooltip icons are rendered:
![legendary](https://user-images.githubusercontent.com/8464472/174385756-c9789cf2-e1da-43af-9c9d-457485df8862.png)
Part of the border is renderered with half the scale, moving it to the top left.

Fix is extremely simple: adding in `RenderSystem.applyModelViewMatrix();`

P.S.
Inofficial release [here](https://github.com/Fourmisain/BetterEnchantedBooks/releases/tag/1.3.1).