### PR TITLE
Compatibility update (for 1.19)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ modmenu_version=4.0.0
 cloth_config_2_version=7.0.69
 
 # Mod Properties
-mod_version=1.4.0
+mod_version=1.4.1
 maven_group=dev.bernasss12
 archives_base_name=better-enchanted-books

--- a/src/main/java/dev/bernasss12/bebooks/client/gui/tooltip/IconTooltipComponent.java
+++ b/src/main/java/dev/bernasss12/bebooks/client/gui/tooltip/IconTooltipComponent.java
@@ -33,5 +33,6 @@ public record IconTooltipComponent(List<ItemStack> icons) implements TooltipComp
             itemRenderer.renderInGuiWithOverrides(icons.get(i), scaledX + scaledOffset * i, scaledY, -1);
         }
         matrices.pop();
+        RenderSystem.applyModelViewMatrix();
     }
 }

--- a/src/main/java/dev/bernasss12/bebooks/util/text/IconTooltipDataText.java
+++ b/src/main/java/dev/bernasss12/bebooks/util/text/IconTooltipDataText.java
@@ -25,7 +25,7 @@ public record IconTooltipDataText(List<ItemStack> icons) implements OrderedText,
 
     @Override
     public String getString() {
-        return "This is not supposed to be used as an actual string.";
+        return "";
     }
 
     @Override
@@ -35,7 +35,7 @@ public record IconTooltipDataText(List<ItemStack> icons) implements OrderedText,
 
     @Override
     public MutableText copy() {
-        return Text.literal(getString() + " Do not try to copy this.");
+        return Text.literal(getString());
     }
 
     @Override


### PR DESCRIPTION
Same as #53 but for 1.19.

P.S.
Inofficial release [here](https://github.com/Fourmisain/BetterEnchantedBooks/releases/tag/1.4.1).